### PR TITLE
Add popover and quick fill buttons to probability calculator

### DIFF
--- a/probability/index.css
+++ b/probability/index.css
@@ -700,6 +700,37 @@ canvas {
     font-size: 85%;
 }
 
+/***********
+ * POPOVER *
+ ***********/
+ 
+.popover {
+    width: 400px;
+} 
+
+.popover-content {
+    color: black;
+    font-size: 90%;
+    padding: 0;
+}
+ 
+.popover-data {
+    font-size: 90%;
+}
+
+.popover-data table {
+    margin: 0;
+}
+
+.popover-data td {
+    width: 25%;
+    padding: 4px !important;
+}
+
+.popover-data .header > td {
+    font-weight: bold;
+}
+
 /***************
  * BACKGROUNDS *
  ***************/

--- a/probability/index.css
+++ b/probability/index.css
@@ -233,6 +233,14 @@ slot-wheel > .ghoster {
     background: #ddd;
 }
 
+.quick-fill-slots {
+	margin: 2px auto;
+}
+
+.quick-fill-skillups {
+	display: inline-block;
+}
+
 .label.label-danger {
     display: inline-block;
     white-space: nowrap;

--- a/probability/index.html
+++ b/probability/index.html
@@ -38,6 +38,8 @@
 
         <script src="../common/data/units.js"></script>
         <script src="../common/data/aliases.js"></script>
+        <script src="../common/data/details.js"></script>
+        <script src="../common/data/cooldowns.js"></script>
         <script src="../common/data/abilities.js"></script>
 
         <script src="../common/js/utils.js"></script>

--- a/probability/js/controllers.js
+++ b/probability/js/controllers.js
@@ -104,7 +104,7 @@ controllers.MainCtrl = ['$scope', '$rootScope', '$state', '$stateParams', '$cont
 	};
 	
     $rootScope.changeUnit = function(unit, uid) {
-        $scope.character = { uid: uid, slots: [ ] };
+        $scope.character = { uid: uid, slots: [ ], name: $scope.returnName(uid) };
 		$scope.slots = $scope.slotCount(uid);
     };
 
@@ -117,6 +117,11 @@ controllers.MainCtrl = ['$scope', '$rootScope', '$state', '$stateParams', '$cont
     $scope.slotCount = function(uid) {
         if (!uid) return 0;
         return units[uid - 1].slots;
+    };
+    
+    $scope.returnName = function(uid) {
+    	if (!uid) return;
+    	return units[uid - 1].name;
     };
 
     $scope.onRemove = function(i) {
@@ -248,6 +253,25 @@ controllers.ResetCtrl = function($scope, $rootScope, $state) {
 
 controllers.InstructionCtrl = function() {
     //Do nothing
+};
+
+/***************
+ * PopoverCtrl *
+ ***************/
+
+controllers.PopoverCtrl = function($scope) {
+    if (!$scope.character) return;
+    var id = $scope.character.uid;
+    $scope.details = window.details[id] ? JSON.parse(JSON.stringify(window.details[id])) : null;
+    $scope.cooldown = window.cooldowns[id - 1];
+    if (!$scope.details || !$scope.details.special) return;
+    if ($scope.details.special.japan)
+        $scope.details.special = $scope.details.special.japan;
+    if ($scope.details.special.constructor == Array) {
+        var lastStage = $scope.details.special.slice(-1)[0];
+        $scope.cooldown = lastStage.cooldown;
+        $scope.details.special = lastStage.description;
+    }
 };
 
 /******************

--- a/probability/js/controllers.js
+++ b/probability/js/controllers.js
@@ -123,6 +123,20 @@ controllers.MainCtrl = ['$scope', '$rootScope', '$state', '$stateParams', '$cont
     	if (!uid) return;
     	return units[uid - 1].name;
     };
+    
+    $scope.quickFillSlots = function() {
+        $scope.character.slots = [ ];
+        for (var i=0;i<$scope.slots;++i)
+        	$scope.character.slots.push({ id: [ 2, 3, 1, 6, 4][i], level: 0 });
+    };
+    
+    $scope.quickFillSkillups = function(uid) {
+    	if (!uid) return;
+    	var cooldown = window.cooldowns[uid - 1];
+    	var maxSkillups = cooldown[0] - cooldown[1];
+    	if (!maxSkillups) return;
+    	$scope.skillups = maxSkillups;
+    };
 
     $scope.onRemove = function(i) {
         $rootScope.character = null;

--- a/probability/views/fragments/popover.html
+++ b/probability/views/fragments/popover.html
@@ -1,0 +1,22 @@
+<div class="popover-data" ng-controller="PopoverCtrl">
+
+    <table class="table table-striped">
+        <tbody>
+            <tr class="header">
+                <td colspan="5">Special</td>
+            </tr>
+            <tr>
+                <td colspan="5">
+                    <div class="special" ng-if="details.special && cooldown">
+                    	{{details.special}}
+                    </div>
+                    <div class="cooldown" ng-if="details.special && cooldown">
+                        {{cooldown.length ? cooldown[0] : cooldown}} turns
+                        {{cooldown.length ? ' (maxed: ' + cooldown[1] + ' turns)' : ''}}
+                    </div>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+
+</div>

--- a/probability/views/main.html
+++ b/probability/views/main.html
@@ -18,6 +18,10 @@
                     </div>
                     <p ng-if="slotCount(character.uid)">Select which Sockets your Unit already has.</p>
                     <p ng-if="!slotCount(character.uid)">This Unit has no Sockets.</p>
+                    <div class="quick-fill quick-fill-slots" 
+                    	ng-class="{ visible: character.uid }" ng-click="quickFillSlots()">
+                        Quick fill
+                    </div>
                     <div class="slots">
 
                         <slot-wheel ng-repeat="slotNumber in range(0, slotCount(character.uid))">
@@ -40,6 +44,10 @@
                     <p></p>
 					Number of Skill-Ups You Need: <input type="text" class="number-field" ng-model="skillups" placeholder="e.g. 10" auto-focus
 						ng-change="changeBaseValues()" id="skillups">
+					<div class="quick-fill quick-fill-skillups" 
+						ng-class="{ visible: character.uid }" ng-click="quickFillSkillups(character.uid)">
+                        Quick fill
+                    </div>
 					
 				</div>
 				

--- a/probability/views/main.html
+++ b/probability/views/main.html
@@ -10,7 +10,10 @@
                     <div class="unitContainer">
 
                         <div class="unit" decorate-slot uid="character.uid"
-                            ng-class="{ empty: !character || !character.uid }"></div>
+                            ng-class="{ empty: !character || !character.uid }"
+                            popover-placement="right" popover-enable="{{character}}"
+                            popover-trigger="mouseenter" popover-title="{{character.name}}"
+                            uib-popover-template="'views/fragments/popover.html'"></div>
 
                     </div>
                     <p ng-if="slotCount(character.uid)">Select which Sockets your Unit already has.</p>


### PR DESCRIPTION
optc-db/optc-db.github.io#44

Copied over existing popover code from damage to probability. Reduced popover template to minimum information necessary (i.e. it only shows the special and its cooldown).

Also copied quick fill buttons from slot planner to probability.