### PR TITLE
G orbs on Sakazuki's long press

### DIFF
--- a/damage/js/directives.js
+++ b/damage/js/directives.js
@@ -608,7 +608,7 @@ directives.unitOrb = function($rootScope) {
 							var unit = scope.data.team[scope.slot], tunit = scope.tdata.team[scope.slot];
 							var n = ORBS.indexOf(tunit.orb);
 							if(unit.unit.type == "STR" || unit.unit.type == "DEX")
-								tunit.orb = ORBS[(n + 1) % ($rootScope.areGOrbsEnabled() || $rootScope.areSTROrbsEnabled() ? ORBS.length - 1 : ORBS.length - 2)];
+								tunit.orb = ORBS[(n + 1) % ($rootScope.areGOrbsEnabled() ? ORBS.length - 1 : ORBS.length - 2)];
 							else
 								tunit.orb = ORBS[(n + ((!$rootScope.areGOrbsEnabled() && $rootScope.areSTROrbsEnabled() && n == ORBS.length - 3) ? 2 : 1)) % ($rootScope.areGOrbsEnabled() ? ($rootScope.areSTROrbsEnabled() ? ORBS.length : ORBS.length - 1) : ($rootScope.areSTROrbsEnabled() ? ORBS.length : ORBS.length - 2))];
 							scope.glow();


### PR DESCRIPTION
The problem wasn't solved. If you use a team with Sakazuki and change orbs by long pressing (not by clicking in the orbs), G orbs will appear. The pull request solved that