### PR TITLE
change borsalino captain ability to be activated by captain actions

### DIFF
--- a/common/data/captains.js
+++ b/common/data/captains.js
@@ -3218,14 +3218,30 @@ window.captains = {
         }
     },
     1239: {
-        atk: function(p){ 
-            return window.specials[1239].turnedOn || window.specials[1240].turnedOn ? 3 : 2; },
+    	atk: function(p){ 
+        	let captId = p.captain ? p.captain.number+1 : null;
+        	let friendId = p.friendCaptain ? p.friendCaptain.number+1 : null;
+        	if ((p.sourceSlot == 0 && (captId == 1239 || captId == 1240)) 
+        			|| (p.sourceSlot == 1 && (friendId == 1239 || friendId == 1240)))
+        	{
+        		// either captain action can activate ability
+        		return p.actions[0] || p.actions[1] ? 3 : 2;
+        	}
+        	return p.actions[p.sourceSlot] ? 3 : 2; },
         rcv: function(p) { return 1.3 }
     },
     1240: {
         atk: function(p){ 
-            return window.specials[1239].turnedOn || window.specials[1240].turnedOn ? 3 : 2; },
-        rcv: function(p) { return 1.3 }
+        	let captId = p.captain ? p.captain.number+1 : null;
+        	let friendId = p.friendCaptain ? p.friendCaptain.number+1 : null;
+        	if ((p.sourceSlot == 0 && (captId == 1239 || captId == 1240)) 
+        			|| (p.sourceSlot == 1 && (friendId == 1239 || friendId == 1240)))
+        	{
+        		// either captain action can activate ability
+        		return p.actions[0] || p.actions[1] ? 3 : 2;
+        	}
+        	return p.actions[p.sourceSlot] ? 3 : 2; },
+    	rcv: function(p) { return 1.3 }
     },
     1241: {
         chainModifier: function(p) { return 1.5; }

--- a/common/data/specials.js
+++ b/common/data/specials.js
@@ -1803,6 +1803,7 @@ window.specials = {
         hit: function(n) { return n > 30 ? 2 : 1; },
         type: "condition"
     },
+    /*
     1239: {
         turnedOn: false,
         onActivation: function(p) {
@@ -1829,6 +1830,7 @@ window.specials = {
             window.specials[1240].turnedOn = false;
         }
     },
+    */
     1241: {
         staticMult: function(p) { return 15; }
     },


### PR DESCRIPTION
#49 

The issue is that specials are a simple toggle. So having 2 Borsalinos in the crew (with at least 1 as captain/friend), you can activate both specials which will toggle on windows.specials[1240].turnedOn, but as soon as you deactivate one it will toggle it off even though the other special is still active.

Since this captain ability is similar to other captains whose captain ability is activated by their specials (e.g. TS Luffy, LSanji), it makes sense to use the same functionality for consistency's sake. The only difference is that if both captain and friend are Borsalino, then either 1 being active activates both of them.