### PR TITLE
Use one-time binding for CharTable sidebar

### DIFF
--- a/characters/views/sidebar.html
+++ b/characters/views/sidebar.html
@@ -8,8 +8,8 @@
         <i class="pull-right fa fa-{{filters.typeEnabled ? 'chevron-up' : 'chevron-down'}}"></i>
     </span>
     <span ng-model="filters.type" ng-repeat="(n,type) in [ 'STR', 'QCK', 'DEX', 'PSY', 'INT' ]"
-        class="filter {{n < 3 ? 'width-4' : 'width-6'}} type {{type}}" ng-class="{ active: filters.types.indexOf(type) > -1 }"
-        ng-click="onTypeClick($event,type)">{{type}}</span>
+        class="filter {{::n < 3 ? 'width-4' : 'width-6'}} type {{::type}}" ng-class="{ active: filters.types.indexOf(type) > -1 }"
+        ng-click="onTypeClick($event,type)">{{::type}}</span>
 </div>
 
 <div class="filter-container" ng-show="false">
@@ -48,7 +48,7 @@
     </span>
     <span ng-repeat="(n,class) in [ 'Fighter', 'Shooter', 'Slasher', 'Striker', 'Free Spirit', 'Cerebral', 'Powerhouse', 'Driven', 'Evolver', 'Booster' ]"
         class="filter width-6 class" ng-click="onClassClick($event,class)"
-        ng-class="{ active: filters.classes.indexOf(class) > -1 }">{{class}}</span>
+        ng-class="{ active: filters.classes.indexOf(class) > -1 }">{{::class}}</span>
     <span class="filter width-12 exc"  ng-class="{ active: filters.classInclusive === true }"
         ng-model="filters.classInclusive" ng-click="filters.classInclusive = !filters.classInclusive">Exclude Characters with other Classes</span>
     <span class="filter width-12 exc"  ng-class="{ active: filters.noSingleClass === true }"
@@ -62,9 +62,9 @@
         Rarity filters
         <i class="pull-right fa fa-{{filters.rarityEnabled ? 'chevron-up' : 'chevron-down'}}"></i>
     </span>
-    <span ng-repeat="(n,stars) in [ 1, 2, 3, 4, 5, 6 ]" class="filter stars width-4 stars-{{stars}}"
+    <span ng-repeat="(n,stars) in [ 1, 2, 3, 4, 5, 6 ]" class="filter stars width-4 stars-{{::stars}}"
         ng-click="onStarsClick($event,stars)" ng-class="{ active: filters.stars.indexOf(stars) > -1 }"></span>
-    <span ng-repeat="(n,stars) in [ 4, 5, 6 ]" class="filter stars width-4 stars-{{stars}}+"
+    <span ng-repeat="(n,stars) in [ 4, 5, 6 ]" class="filter stars width-4 stars-{{::stars}}+"
         ng-click="onStarsClick($event,stars + '+')" ng-class="{ active: filters.stars.indexOf(stars + '+') > -1 }"></span>
 </div>
 
@@ -117,13 +117,13 @@
         <i class="pull-right fa fa-{{filters.dropEnabled ? 'chevron-up' : 'chevron-down'}}"></i>
     </span>
     <span ng-repeat="type in [ 'Farmable', 'Non-farmable' ]" class="filter width-6 drop" ng-model="filters.drop"
-        ng-class="{ active: filters.drop == type }" ng-click="onFilterClick($event,type)">{{type}}</span>
+        ng-class="{ active: filters.drop == type }" ng-click="onFilterClick($event,type)">{{::type}}</span>
     <span ng-repeat="type in [ 'Global units', 'Japan exclusives' ]" class="filter width-6 drop" ng-model="filters.server"
-        ng-class="{ active: filters.server == type }" ng-click="onFilterClick($event,type)">{{type}}</span>
+        ng-class="{ active: filters.server == type }" ng-click="onFilterClick($event,type)">{{::type}}</span>
     <span ng-repeat="type in [ 'In RR pool', 'Not in RR pool' ]" class="filter width-6 drop" ng-model="filters.rr"
-        ng-class="{ active: filters.rr == type }" ng-click="onFilterClick($event,type)">{{type}}</span>
+        ng-class="{ active: filters.rr == type }" ng-click="onFilterClick($event,type)">{{::type}}</span>
     <span ng-repeat="type in [ 'Farmable Sockets', 'No Farmable Sockets' ]" class="filter width-6 drop" ng-model="filters.socket"
-        ng-class="{ active: filters.socket == type }" ng-click="onFilterClick($event,type)">{{type}}</span>
+        ng-class="{ active: filters.socket == type }" ng-click="onFilterClick($event,type)">{{::type}}</span>
 </div>
 
 <div class="filter-container expandable conditional" id="farmable-filter" ng-show="filters.dropEnabled" ng-class="{ expanded: filters.farmEnabled }">
@@ -364,9 +364,9 @@
         Captain ability filters
         <i class="pull-right fa fa-{{filters.captainEnabled ? 'chevron-up' : 'chevron-down'}}"></i>
     </span>
-    <span class="filter width-12 custom" ng-repeat="(n,filter) in filterData" ng-if="filter.target == 'captain'"
+    <span class="filter width-12 custom" ng-repeat="(n,filter) in ::filterData" ng-if="::filter.target == 'captain'"
         ng-model="filters.custom[n]" ng-class="{ active: filters.custom[n] }" add-captain-options
-        ng-click="filters.custom[n] = !filters.custom[n]">{{filter.name}}</span>
+        ng-click="filters.custom[n] = !filters.custom[n]">{{::filter.name}}</span>
 </div>
 
 <div class="filter-container expandable" id="special-container"
@@ -375,9 +375,9 @@
         Special ability filters
         <i class="pull-right fa fa-{{filters.specialEnabled ? 'chevron-up' : 'chevron-down'}}"></i>
     </span>
-    <span class="filter width-12 custom" ng-repeat="(n,filter) in filterData" ng-if="filter.target == 'special'"
+    <span class="filter width-12 custom" ng-repeat="(n,filter) in ::filterData" ng-if="::filter.target == 'special'"
         ng-model="filters.custom[n]" ng-class="{ active: filters.custom[n] }" add-orb-options add-special-options
-        ng-click="filters.custom[n] = !filters.custom[n]">{{filter.name}}</span>
+        ng-click="filters.custom[n] = !filters.custom[n]">{{::filter.name}}</span>
 </div>
 
 <div class="filter-container expandable" id="swap-container"
@@ -386,9 +386,9 @@
         Swap ability filters
         <i class="pull-right fa fa-{{filters.swapEnabled ? 'chevron-up' : 'chevron-down'}}"></i>
     </span>
-    <span class="filter width-12 custom" ng-repeat="(n,filter) in filterData" ng-if="filter.target == 'swap'"
+    <span class="filter width-12 custom" ng-repeat="(n,filter) in ::filterData" ng-if="::filter.target == 'swap'"
         ng-model="filters.custom[n]" ng-class="{ active: filters.custom[n] }" 
-        ng-click="filters.custom[n] = !filters.custom[n]">{{filter.name}}</span>
+        ng-click="filters.custom[n] = !filters.custom[n]">{{::filter.name}}</span>
 </div>
 
 <div class="filter-container expandable" id="sailor-container"
@@ -397,9 +397,9 @@
         Sailor ability filters
         <i class="pull-right fa fa-{{filters.sailorEnabled ? 'chevron-up' : 'chevron-down'}}"></i>
     </span>
-    <span class="filter width-12 custom" ng-repeat="(n,filter) in filterData" ng-if="filter.target == 'sailor'"
+    <span class="filter width-12 custom" ng-repeat="(n,filter) in ::filterData" ng-if="::filter.target == 'sailor'"
         ng-model="filters.custom[n]" ng-class="{ active: filters.custom[n] }" add-sailor-options
-        ng-click="filters.custom[n] = !filters.custom[n]">{{filter.name}}</span>
+        ng-click="filters.custom[n] = !filters.custom[n]">{{::filter.name}}</span>
 </div>
 
 <div class="filter-container expandable" id="limit-container"
@@ -408,9 +408,9 @@
         Limit Break filters
         <i class="pull-right fa fa-{{filters.limitEnabled ? 'chevron-up' : 'chevron-down'}}"></i>
     </span>
-    <span class="filter width-12 custom" ng-repeat="(n,filter) in filterData" ng-if="filter.target == 'limit'"
+    <span class="filter width-12 custom" ng-repeat="(n,filter) in ::filterData" ng-if="::filter.target == 'limit'"
         ng-model="filters.custom[n]" ng-class="{ active: filters.custom[n] }" 
-        ng-click="filters.custom[n] = !filters.custom[n]">{{filter.name}}</span>
+        ng-click="filters.custom[n] = !filters.custom[n]">{{::filter.name}}</span>
 </div>
 
 <div class="filter-container expandable" id="support-container"
@@ -419,9 +419,9 @@
         Support ability filters
         <i class="pull-right fa fa-{{filters.supportEnabled ? 'chevron-up' : 'chevron-down'}}"></i>
     </span>
-    <span class="filter width-12 custom" ng-repeat="(n,filter) in filterData" ng-if="filter.target == 'support'"
+    <span class="filter width-12 custom" ng-repeat="(n,filter) in ::filterData" ng-if="::filter.target == 'support'"
         ng-model="filters.custom[n]" ng-class="{ active: filters.custom[n] }" add-support-options
-        ng-click="filters.custom[n] = !filters.custom[n]">{{filter.name}}</span>
+        ng-click="filters.custom[n] = !filters.custom[n]">{{::filter.name}}</span>
 </div>
 
 <!--div class="filter-container">


### PR DESCRIPTION
Static data do not need watchers (which get processed every digest
cycle). I applied the one-time binding feature for parts in the code
where the data is not expected to change during runtime, namely the
text of the filters (from matchers.js, which is also not changed during
runtime). This is done by adding "::" before the variables. This
removes watchers from the variables after the value is defined
(basically evaluate-once).

I used the Chrome extension [Angular Watchers](https://chrome.google.com/webstore/detail/angular-watchers/nlmjblobloedpmkmmckeehnbfalnjnjk)
to test out the number of watchers in the page. Once it is installed,
it can be found in the browser's developer tools as a tab named
"$$Watchers" (unfortunately not mentioned in the
extension's description)

I made sure that each change reduces the number of watchers, while not
affecting functionality (turning the filters on and off are working).
The observed watcher count reduction for each type of change
for #captain-container and the succeeding elements is listed as follows.

Variables (what appears as text): Number of filters for the section
    (47 for captain, 113 for special, etc)
ngRepeat: 1
ngIf: 279 (number of all matchers)

Interestingly, ngIf has watchers for each element in ngRepeat's array,
so basically each section (captain, special, support, etc) had watchers
for all of them, which is 279 (as of this writing) for EACH section.

Note that I did not use it for the ngClass directives, as we do need
those bindings for appearance.

Applying this to all sections from captain ability filters reduced
watchers from 2857 to 899 (~69% reduction).

I then applied this to all the other sections with ng-Repeat.
Even if the arrays in their ngRepeat directives were literal arrays,
their variables still had a few watchers. This brought the final count to 876.

Tested in Microsoft Edge 91.0.864.48 (64-bit).

I do hope to apply this feature in other views as well.

Additional references:
https://docs.angularjs.org/guide/expression#one-time-binding
https://www.qualtrics.com/eng/tuning-angularjs-performance/