### PR TITLE
Fix searchEvolverEvolutions for multiple evos

### DIFF
--- a/characters/js/utils.js
+++ b/characters/js/utils.js
@@ -72,13 +72,23 @@ CharUtils.generateSearchParameters = function(query, filters) {
 CharUtils.searchEvolverEvolutions = function(id) {
     var result = { }, current = parseInt(id,10);
     for (var key in evolutions) {
+        var evolutionObj = Object.assign({}, evolutions[key]);
         var paddedId = ('000' + key).slice(-4);
-        if (!evolutions[key].evolution) continue;
-        if (evolutions[key].evolvers.indexOf(current) != -1)
-            result[paddedId] = (result[paddedId] || [ ]).concat([ evolutions[key].evolution ]);
-        for (var i=0;i<evolutions[key].evolution.length;++i) {
-            if (evolutions[key].evolvers[i].indexOf(current) != -1)
-                result[paddedId] = (result[paddedId] || [ ]).concat([ evolutions[key].evolution[i] ]);
+        if (!evolutionObj.evolution) continue;
+        if (evolutionObj.evolvers.indexOf(current) != -1) {
+            if (!result[paddedId])
+                result[paddedId] = [];
+            result[paddedId].push(evolutionObj);
+        }
+        for (var i=0;i<evolutionObj.evolution.length;++i) { // Multiple evos
+            if (evolutionObj.evolvers[i].indexOf(current) != -1) {
+                if (!result[paddedId])
+                    result[paddedId] = [];
+                result[paddedId].push({
+                    evolution: evolutionObj.evolution[i],
+                    evolvers: evolutionObj.evolvers[i]
+                });
+            }
         }
     }
     return result;

--- a/characters/views/details.html
+++ b/characters/views/details.html
@@ -925,9 +925,9 @@
                             </tr>
                             <tr ng-repeat="(base,evolutions) in usedBy" ng-if="!collapsed.used || sizeOf(usedBy) < 4">
                                 <td>
-                                    <div ng-repeat="id in evolutions track by $index">
-                                        <evolution unit="unit" base="base" evolvers="getEvos(base,id,unit.number + 1)"
-                                            evolution="id" size="medium"></evolution>
+                                    <div ng-repeat="data in evolutions track by $index">
+                                        <evolution unit="unit" base="base" evolvers="data.evolvers"
+                                            evolution="data.evolution" size="medium"></evolution>
                                     </div>
                                 </td>
                             </tr>


### PR DESCRIPTION
Fixes #30 where "Evolutions Requiring This Unit" will show identical
evolution chains instead of all variations. This fixes all boosters like
penguin ID 87 for Sentomaru's evolutions.

This change makes CharUtils.getEvolversOfEvolution and $scope.getEvos in
DetailsCtrl obsolete as they are no longer called anywhere in the code
base, though they are left untouched in this commit. I would like to have
your opinion on these two.