### PR TITLE
Fix missing sourceSlot property

### DIFF
--- a/damage/js/cruncher.js
+++ b/damage/js/cruncher.js
@@ -1067,6 +1067,7 @@ var CruncherCtrl = function($scope, $rootScope, $timeout) {
             var unitParams = params;
             //Check if conditional Boosts are activated since they raise 
             for (var x=0;x<enabledSpecials.length;++x) {
+                params.sourceSlot = enabledSpecials[x].sourceSlot;
                 if  (enabledSpecials[x].type=='condition'){
                     var thisMult = enabledSpecials[x].atk(params);
                     if(thisMult>conditionalMultiplier){


### PR DESCRIPTION
Certain specials that access the property, like Magellan/Hannyabal's,
were not working if you had a sailor or special that adds additional
damage like Kung Fu Luffy and Raid Sabo.

Minimal test case:
1. Magellan/Hannyabal as captain (either type).
2. Enable their special and verify that the special works. 
3. Disable the special.
4. Add Kung Fu Luffy as sailor.
5. Enable Magellan/Hannyabal's special. The special will not work anymore
    without the fix.