### PR TITLE
Fix rumble2 typo in character details

### DIFF
--- a/characters/js/controllers.js
+++ b/characters/js/controllers.js
@@ -179,6 +179,7 @@ app.controller('DetailsCtrl',function($scope, $rootScope, $state, $stateParams, 
             if ($scope.rumble === undefined ) {
               console.log("Couldn't find unit with id " + id);
               $scope.rumble={};
+              return;
             }
             // normalize the data here:
             denormalizeEffects($scope.rumble.ability);

--- a/characters/views/details.html
+++ b/characters/views/details.html
@@ -194,7 +194,7 @@
                                         <td ng-if="!compare">{{rumble2.stats.def | number}}</td>
                                         <td ng-if="compare" comparison="positive">{{rumble2.stats.def - compare.rumble2.stats.def | number}}</td>
                                         <td ng-if="!compare">{{rumble2.stats.spd | number}}</td>
-                                        <td ng-if="compare" comparison="positive">{{rumble.stats.spd - compare.rumble2.stats.spd | number}}</td>
+                                        <td ng-if="compare" comparison="positive">{{rumble2.stats.spd - compare.rumble2.stats.spd | number}}</td>
                                     </tr>
                                 </tbody>
                             </table>


### PR DESCRIPTION
Also fixes single characters without data in rumble.json showing
both "Character 1" and "Character 2".