### PR TITLE
Make searching independent of word order

### DIFF
--- a/characters/js/table.js
+++ b/characters/js/table.js
@@ -92,13 +92,14 @@ angular.module('optc') .run(function($rootScope, $timeout, $storage, MATCHER_IDS
                     stat < tableData.parameters.ranges[range][0] || stat > tableData.parameters.ranges[range][1])
                 return false;
         }
-        // filter by query
-        if (tableData.parameters.query) {
+        // filter by queryTerms
+        if (tableData.parameters.queryTerms && tableData.parameters.queryTerms.length > 0) {
             var name = Utils.getFullUnitName(id);
-            if (!tableData.fuzzy && !tableData.parameters.query.test(name)) return false;
             if (tableData.fuzzy) {
-                if (fused === null) fused = fuse.search(tableData.parameters.query.source || 'xyz');
+                if (fused === null) fused = fuse.search(tableData.parameters.query);
                 if (fused.indexOf(id - 1) == -1) return false;
+            } else if (!tableData.parameters.queryTerms.every(term => term.test(name))){
+                return false;
             }
         }
         /* * * * * Sidebar filters * * * * */

--- a/common/js/utils.js
+++ b/common/js/utils.js
@@ -1048,7 +1048,7 @@
         if (!query || query.trim().length < 2)
             return null;
         query = query.toLowerCase().trim();
-        var result = {matchers: {}, ranges: {}, query: []};
+        var result = {matchers: {}, ranges: {}, query: [], queryTerms: []};
         var ranges = {}, params = ['hp', 'atk', 'stars', 'cost', 'growth', 'rcv', 'id', 'slots', 'combo', 'exp', 'minCD', 'maxCD'];
         var regex = new RegExp('^((type|class|support):(\\w+\\s{0,1}\\w+)|(' + params.join('|') + ')(>|<|>=|<=|=)([-?\\d.]+))$', 'i');
         var tokens = query.replace(/\s+/g, ' ').split(' ').filter(function (x) {
@@ -1057,9 +1057,10 @@
         tokens.forEach(function (x) {
             x = x.replace("_", ' ');
             var temp = x.match(regex);
-            if (!temp) // if it couldn't be parsed, treat it as string
+            if (!temp) { // if it couldn't be parsed, treat it as string
                 result.query.push(x);
-            else if (temp[4] !== undefined) { // numeric operator
+                result.queryTerms.push(utils.getRegex(x));
+            } else if (temp[4] !== undefined) { // numeric operator
                 var parameter = temp[4],
                         op = temp[5],
                         value = parseFloat(temp[6], 10);
@@ -1091,7 +1092,7 @@
                 //console.log(result.matchers); Here for stuff to try to do custom
         });
         if (result.query.length > 0)
-            result.query = utils.getRegex(result.query.join(' '));
+            result.query = result.query.join(' ');
         else
             result.query = null;
         return result;

--- a/damage/js/controllers.js
+++ b/damage/js/controllers.js
@@ -83,10 +83,11 @@ controllers.PickerCtrl = function($scope, $state, $stateParams, $storage) {
                 return true;
             });
         }
-        // filter by query
-        if (parameters.query) {
+        // filter by queryTerms
+        if (parameters.queryTerms) {
+            var name = Utils.getFullUnitName(unit.number + 1);
             result = result.filter(function(unit) {
-                return parameters.query.test(Utils.getFullUnitName(unit.number + 1));
+                return parameters.queryTerms.every(term => term.test(name));
             });
         }
         $scope.units = result;

--- a/mats/index.js
+++ b/mats/index.js
@@ -259,10 +259,11 @@ app.controller('PickerCtrl',function($scope, $rootScope, $state, $stateParams, $
         var result, parameters = Utils.generateSearchParameters($scope.query);
         if (parameters === null) return;
         result = window.units.filter(function(x) { return x !== null && x !== undefined && x.hasOwnProperty('number'); });
-        // filter by query
-        if (parameters.query) {
+        // filter by queryTerms
+        if (parameters.queryTerms && parameters.queryTerms.length > 0) {
             result = result.filter(function(unit) {
-                return parameters.query.test(Utils.getFullUnitName(unit.number + 1));
+                let name = Utils.getFullUnitName(unit.number + 1);
+                return parameters.queryTerms.every(term => term.test(name));
             });
         }
         $scope.units = result;

--- a/probability/js/controllers.js
+++ b/probability/js/controllers.js
@@ -221,10 +221,11 @@ controllers.PickerCtrl = function($scope, $state, $stateParams, $storage) {
         var result, parameters = Utils.generateSearchParameters($scope.query);
         if (parameters === null) return;
         result = window.units.filter(function(x) { return x !== null && x !== undefined && x.hasOwnProperty('number'); });
-        // filter by query
-        if (parameters.query) {
+        // filter by queryTerms
+        if (parameters.queryTerms && parameters.queryTerms.length > 0) {
             result = result.filter(function(unit) {
-                return parameters.query.test(Utils.getFullUnitName(unit.number + 1));
+                let name = Utils.getFullUnitName(unit.number + 1);
+                return parameters.queryTerms.every(term => term.test(name));
             });
         }
         $scope.units = result;

--- a/slots/js/controllers.js
+++ b/slots/js/controllers.js
@@ -134,10 +134,11 @@ controllers.PickerCtrl = function($scope, $state, $stateParams, $storage) {
         var result, parameters = Utils.generateSearchParameters($scope.query);
         if (parameters === null) return;
         result = window.units.filter(function(x) { return x !== null && x !== undefined && x.hasOwnProperty('number'); });
-        // filter by query
-        if (parameters.query) {
+        // filter by queryTerms
+        if (parameters.queryTerms && parameters.queryTerms.length > 0) {
             result = result.filter(function(unit) {
-                return parameters.query.test(Utils.getFullUnitName(unit.number + 1));
+                let name = Utils.getFullUnitName(unit.number + 1);
+                return parameters.queryTerms.every(term => term.test(name));
             });
         }
         $scope.units = result;


### PR DESCRIPTION
This puts all the searchTerms in an array so that they may be
tested individually. This will reduce the need for multiple variants of
aliases. Like the prior code, the searchTerms are matched against a
string composed of the unit name and the aliases. The previous
`result.query` is retained for the fuzzy search, though it is now
returned as a string instead of a regex. If the fuzzy search can be
revised to use `result.queryTerms`, `result.query` may be removed.

String and mathematical operators in the query are unaffected, and can
be in between searchTerms.

Simple tests to see the difference between the previous searching and
this commit's are "legend v2 akainu", "nami hug", and "tm zanji".

If you want this to match against each alias individually (looping through
the names and aliases instead of against the combined string), let me
know, but I believe it is not necessary. It would also require more aliases
(though less than the previous) and may add a bit more performance
overhead.