### PR TITLE
Treat numbers-only query as id

### DIFF
--- a/characters/js/utils.js
+++ b/characters/js/utils.js
@@ -48,10 +48,6 @@ var flagUnit = function(id, type) {
 /* * * * * Public methods * * * * */
 
 CharUtils.generateSearchParameters = function(query, filters) {
-    if (/^\d+$/.test(query)) {
-        var n = parseInt(query,10);
-        if (n > 0 && n <= units.length) query = 'id=' + query;
-    }
     var result = Utils.generateSearchParameters(query);
     if (result === null && Object.keys(filters).length === 0) return null;
     if (filters.class && filters.class.constructor != RegExp) filters.class = new RegExp(filters.class,'i');

--- a/common/js/utils.js
+++ b/common/js/utils.js
@@ -1213,6 +1213,10 @@
     utils.generateSearchParameters = function (query) {
         if (!query || query.trim().length < 2)
             return null;
+        if (/^\d+$/.test(query)) {
+            var n = parseInt(query,10);
+            if (n > 0 && n <= units.length) query = 'id=' + query;
+        }
         query = utils.normalizeText(query.toLowerCase().trim());
         var result = {matchers: {}, ranges: {}, query: [], queryTerms: []};
         var ranges = {}, params = ['hp', 'atk', 'stars', 'cost', 'growth', 'rcv', 'id', 'slots', 'combo', 'exp', 'minCD', 'maxCD'];


### PR DESCRIPTION
CharTable automatically appends "id=" to the query when the whole query
is just a number. This applies this to the main utility function
Utils.generateSearchParameters so that it applies to all other
components.