### PR TITLE
Fix(damage): transfer links being broken

### DIFF
--- a/damage/js/cruncher.js
+++ b/damage/js/cruncher.js
@@ -74,11 +74,12 @@ var CruncherCtrl = function($scope, $rootScope, $timeout) {
     var hitModifiers = [ ];
     var shipBonus = { };
     var enabledSpecials = [ ];
+    var enabledEffects = [ ];
 
     var crunchSelfInhibit = false;
     var mapEffect = { };
     var team = [ ];
-    var initDone = false;
+    $rootScope.cruncherReady = false;
     
     var gearLevel = [ 0, 0 ];
 
@@ -92,8 +93,6 @@ var CruncherCtrl = function($scope, $rootScope, $timeout) {
         var params = getParameters(slot); params["sourceSlot"] = slot;
         if (!specials.hasOwnProperty(id)) return;
         if (enabled && specials[id].hasOwnProperty('onActivation')) {
-            if (!initDone) initializeDataStructs();
-            
             /*var kataActivate = false;
             for(var kata = 0; kata < 2; kata++){
             if(team[kata].unit !== null){
@@ -111,7 +110,6 @@ var CruncherCtrl = function($scope, $rootScope, $timeout) {
             
             specials[id].onActivation(params);
         } else if (!enabled && specials[id].hasOwnProperty('onDeactivation')) {
-            if (!initDone) initializeDataStructs();
             specials[id].onDeactivation(params);
         }
     });
@@ -123,7 +121,6 @@ var CruncherCtrl = function($scope, $rootScope, $timeout) {
         var params = getParameters(slot); params["sourceSlot"] = slot;
         if (!altspecials.hasOwnProperty(id)) return;
         if (enabled && altspecials[id].hasOwnProperty('onActivation')) {
-            if (!initDone) initializeDataStructs();
             
             /*var kataActivate = false;
             for(var kata = 0; kata < 2; kata++){
@@ -142,15 +139,12 @@ var CruncherCtrl = function($scope, $rootScope, $timeout) {
             
             altspecials[id].onActivation(params);
         } else if (!enabled && altspecials[id].hasOwnProperty('onDeactivation')) {
-            if (!initDone) initializeDataStructs();
             altspecials[id].onDeactivation(params);
         }
     });
 
     $scope.$watch('data',crunch,true);
     $scope.$watch('tdata',crunch,true);
-
-    $rootScope.cruncherReady = true;
 
     /* * * * * Crunching * * * * */
 
@@ -1256,7 +1250,7 @@ var CruncherCtrl = function($scope, $rootScope, $timeout) {
     /* * * * * * Utility functions * * * * */
 
     var initializeDataStructs = function() {
-        initDone = true;
+        $rootScope.cruncherReady = true;
         // get enabled specials
         var conflictWarning = false;
         enabledSpecials = [ ];


### PR DESCRIPTION
Really just needed to set cruncherReady to true after
`initializeDataStructs` (or other similar solutions), and add a missing
variable up top, but I opted to clean up the `initDone`, which seemed to
be added as a quick patch.