### PR TITLE
Fix(characters): fix orb controller partially

### DIFF
--- a/characters/js/table.js
+++ b/characters/js/table.js
@@ -418,7 +418,7 @@ angular.module('optc') .run(function($rootScope, $timeout, $storage, MATCHER_IDS
         if (filters.noMissing && !characterLog.hasOwnProperty(id)) return false;
         // filter by orb controllers
         if ($rootScope.filters.custom[MATCHER_IDS['special.OrbControllers']] &&
-                (tableData.parameters.filters.ctrlFrom || tableData.parameters.filters.ctrlTo)) {
+                ((tableData.parameters.filters.ctrlFrom && tableData.parameters.filters.ctrlFrom.length > 0) || (tableData.parameters.filters.ctrlTo && tableData.parameters.filters.ctrlTo.length > 0))) {
             var orbData = CharUtils.getOrbControllerData(id);
             if (!orbData) return false;
             var from = tableData.parameters.filters.ctrlFrom || [ ], to = tableData.parameters.filters.ctrlTo || [ ];


### PR DESCRIPTION
If you enable "Orb controllers" filter, and pick any of the orbs, then
deselect that orb, the filtered units will be less than before, even if
no orbs are selected. This is due to the algorithm for the orbs using a
different regex than what is used by the main filter. This fixes this
issue, but does not fix all the bugs with the orb controller (which
would require rewording all orb controllers to follow a strict format).