### PR TITLE
Fix: Supports operator ignoring cost-supporters

### DIFF
--- a/common/js/utils.js
+++ b/common/js/utils.js
@@ -208,7 +208,25 @@
 
         let costMatch = criteria.match(costRegex);
         if (costMatch){
-            matchers.push('cost' + (costMatch[2] == 'less' ? '<=' : '>=') + costMatch[1]);
+            let op = costMatch[2] == 'less' ? '<=' : '>=';
+            let value = costMatch[1];
+            matchers.push('cost' + op + value);
+            if (returnParamsObject) {
+                params.ranges = {cost: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]};
+
+                if (op === '=') {
+                    params.ranges['cost'][0] = value;
+                    params.ranges['cost'][1] = value;
+                } else if (op === '<') {
+                    params.ranges['cost'][1] =  value - 1;
+                } else if (op === '<=') {
+                    params.ranges['cost'][1] = value;
+                } else if (op === '>') {
+                    params.ranges['cost'][0] =  value + 1;
+                } else if (op === '>=') {
+                    params.ranges['cost'][0] =  value;
+                }
+            }
         } else {
             criteria = criteria.replace(aliasesRegex, '');
             let terms = criteria.split(separatorRegex);


### PR DESCRIPTION
Doing any `supports:xxxx` resulted in showing units 459, 1079, 1391,
1847, 2035 regardless of the cost of unit xxxx as reported in
https://discord.com/channels/154354574281539584/154355744043433984/946083349385072700