### PR TITLE
Enclose matchers.js in function

### DIFF
--- a/common/data/matchers.js
+++ b/common/data/matchers.js
@@ -1,3 +1,4 @@
+(function () {
 /**
  * These are the `filters.custom` in "characters\js\table.js", used to "match"
  * ability descriptions in "common\data\details.js"
@@ -4763,3 +4764,5 @@ if (alphabeticalOrder){
         }
     }
 }
+
+})();


### PR DESCRIPTION
This makes it so the variables it uses will be scoped to the file, so
it won't override variables that are used in other files (like support
DB using the variable "matchers" somewhere else). This should
(hopefully) fix the support DB not showing data.