### PR TITLE
Fix click css classes on mobile

### DIFF
--- a/characters/css/edgy.css
+++ b/characters/css/edgy.css
@@ -11,11 +11,13 @@ html, body,
     border-color: #333;
 }
 
-.filter:hover:not(.type):not(.stars):not(.orb):not(.custom),
-.filter.custom > div:first-child:hover,
-.filter .submatchers .submatcher .submatcher-option:hover {
-    color: #f6f3e8 !important;
-    background: #bb4040 !important;
+@media (hover) {
+    .filter:hover:not(.type):not(.stars):not(.orb):not(.custom),
+    .filter.custom > div:first-child:hover,
+    .filter .submatchers .submatcher .submatcher-option:hover {
+        color: #f6f3e8 !important;
+        background: #bb4040 !important;
+    }
 }
 
 #leftContainer .custom.filter .submatchers {
@@ -51,13 +53,15 @@ html, body,
     box-shadow: inset 0 0 0 1px #aaaaff;
 }
 
-.class.filter.active:not(.type):not(.stars):not(.orb):hover,
-.custom.filter.active:not(.type):not(.stars):not(.orb) > div:first-child:hover,
-.drop.filter.active:hover:not(.type):not(.stars):not(.orb),
-.exc.filter.active:hover:not(.type):not(.stars):not(.orb),
-.filter .submatchers .submatcher .submatcher-option.active:hover {
-    background: #ff9090 !important;
-    color: #222 !important;
+@media (hover) {
+    .class.filter.active:not(.type):not(.stars):not(.orb):hover,
+    .custom.filter.active:not(.type):not(.stars):not(.orb) > div:first-child:hover,
+    .drop.filter.active:hover:not(.type):not(.stars):not(.orb),
+    .exc.filter.active:hover:not(.type):not(.stars):not(.orb),
+    .filter .submatchers .submatcher .submatcher-option.active:hover {
+        background: #ff9090 !important;
+        color: #222 !important;
+    }
 }
 
 .filter-header:not(#clear-button, #toggle-button, #filter-subheader, .filter-group-header) {
@@ -70,7 +74,9 @@ html, body,
 }
 
 a { color: #8acccf; }
-a:hover { color: #53dccd; }
+@media (hover) {
+    a:hover { color: #53dccd; }
+}
 .help-link { color: #cc9393; }
 #pick-link { color: #a893cc; }
 
@@ -154,12 +160,14 @@ a:hover { color: #53dccd; }
     color: white;
 }
 
-.pagination a:hover {
-    background: #606060 !important;
-}
+@media (hover) {
+    .pagination a:hover {
+        background: #606060 !important;
+    }
 
-.pagination > li:hover > a {
-    color: white;
+    .pagination > li:hover > a {
+        color: white;
+    }
 }
 
 @media (max-width: 1024px) {

--- a/characters/css/index.css
+++ b/characters/css/index.css
@@ -45,8 +45,10 @@ body, html {
     border: none;
 }
 
-#queryContainer > button:hover {
-    text-decoration: underline;
+@media (hover) {
+    #queryContainer > button:hover {
+        text-decoration: underline;
+    }
 }
 
 #leftContainer {
@@ -299,8 +301,10 @@ input#burgerMenuState {
     font-weight: normal;
 }
 
-#leftContainer .submatcher .submatcher-option:hover {
-    background-color: rgb(230,230,230);
+@media (hover) {
+    #leftContainer .submatcher .submatcher-option:hover {
+        background-color: rgb(230,230,230);
+    }
 }
 
 #leftContainer .submatcher .submatcher-option.active {
@@ -314,9 +318,11 @@ input#burgerMenuState {
     background-color: #dd6060;
 }
 
-#leftContainer .custom.filter .custom.filter.submatchers-toggler:hover,
-#leftContainer .custom.filter > .collapse {
-    background-color: #FF9090;
+@media (hover) {
+    #leftContainer .custom.filter .custom.filter.submatchers-toggler:hover,
+    #leftContainer .custom.filter > .collapse {
+        background-color: #FF9090;
+    }
 }
 
 .filter-container:last-child > .filter:last-child {
@@ -327,8 +333,14 @@ input#burgerMenuState {
     border: none;
 }
 
-.type.filter:not(.active):not(:hover), .orb-controllers > span:not(.separator):not(.active):not(:hover) {
+.type.filter:not(.active), .orb-controllers > span:not(.separator):not(.active) {
     opacity: 0.3;
+}
+
+@media (hover) {
+    .type.filter:not(.active):not(:hover), .orb-controllers > span:not(.separator):not(.active):not(:hover) {
+        opacity: 0.3;
+    }
 }
 
 .type.filter.active, .orb-controllers > .active {
@@ -489,8 +501,14 @@ input#burgerMenuState {
     font-size: 13px;
 }
 
-.filter.stars:not(.active):not(:hover):before {
+.filter.stars:not(.active):before {
     color: #cccccc !important;
+}
+
+@media (hover) {
+    .filter.stars:not(.active):not(:hover):before {
+        color: #cccccc !important;
+    }
 }
 
 .stars-1:before { color: #40a3da; content: '\2605'; }
@@ -550,12 +568,14 @@ input#burgerMenuState {
     box-shadow: inset 0 0 0 1px #7777ff;
 }
 
-.custom.filter:not(.orb-controllers) > div:first-child:hover, .class.filter:hover, .drop.filter:hover, .exc.filter:hover, .submatcher-option:hover {
-    background-color: rgb(230,230,230);
-}
+@media (hover) {
+    .custom.filter:not(.orb-controllers) > div:first-child:hover, .class.filter:hover, .drop.filter:hover, .exc.filter:hover, .submatcher-option:hover {
+        background-color: rgb(230,230,230);
+    }
 
-.custom.filter.active > div:first-child:hover, .class.filter.active:hover, .drop.filter.active:hover, .exc.filter.active:hover, .filter .submatchers .submatcher-option.active:hover {
-    background-color: darkred !important;
+    .custom.filter.active > div:first-child:hover, .class.filter.active:hover, .drop.filter.active:hover, .exc.filter.active:hover, .filter .submatchers .submatcher-option.active:hover {
+        background-color: darkred !important;
+    }
 }
 
 .width-12 { width: 100%; }
@@ -641,12 +661,14 @@ input#burgerMenuState {
     color: white;
 }
 
-#clear-button:hover {
-    background: orangered;
-}
+@media (hover) {
+    #clear-button:hover {
+        background: orangered;
+    }
 
-#toggle-button:hover {
-    background: darkviolet;
+    #toggle-button:hover {
+        background: darkviolet;
+    }
 }
 
 .dataTables_info, .dataTables_paginate {
@@ -722,8 +744,10 @@ input#burgerMenuState {
     margin: 0 5px;
 }
 
-.comparer .compare-clear:hover {
-    color: red;
+@media (hover) {
+    .comparer .compare-clear:hover {
+        color: red;
+    }
 }
 
 #compare {
@@ -763,8 +787,10 @@ input#burgerMenuState {
     background-color: rgb(230,230,230);
 }
 
-.tt-suggestion:hover {
-    background-color: lightgray;
+@media (hover) {
+    .tt-suggestion:hover {
+        background-color: lightgray;
+    }
 }
 
 .tt-suggestion .slot {
@@ -855,8 +881,10 @@ input#burgerMenuState {
     vertical-align: middle;
 }
 
-#mainTable th:hover {
-    text-decoration: underline;
+@media (hover) {
+    #mainTable th:hover {
+        text-decoration: underline;
+    }
 }
 
 .table-striped-column > * > tr > :nth-of-type(odd) {
@@ -1188,8 +1216,10 @@ unit > a {
     cursor: pointer;
 }
 
-unit > a:hover, .clickable:hover {
-    outline: 1px solid red !important;
+@media (hover) {
+    unit > a:hover, .clickable:hover {
+        outline: 1px solid red !important;
+    }
 }
 
 .tab-pane + .tab-pane {

--- a/common/css/links.css
+++ b/common/css/links.css
@@ -52,12 +52,14 @@
     padding-top: 7px;
 }
 
-#links-button .btn:hover .fa, .rotater i {
-    color: rgba(0, 0, 0, 0.7);
-}
+@media (hover) {
+    #links-button .btn:hover .fa, .rotater i {
+        color: rgba(0, 0, 0, 0.7);
+    }
 
-.rotater:hover i, .rotater:hover i {
-    color: white !important;
+    .rotater:hover i, .rotater:hover i {
+        color: white !important;
+    }
 }
 
 #links-button .btn.trigger {
@@ -66,18 +68,20 @@
     cursor: pointer;
 }
 
-#links-button .btn.trigger:hover {
-    -webkit-transform: scale(1.2);
-    -ms-transform: scale(1.2);
-    transform: scale(1.2);
-}
+@media (hover) {
+    #links-button .btn.trigger:hover {
+        -webkit-transform: scale(1.2);
+        -ms-transform: scale(1.2);
+        transform: scale(1.2);
+    }
 
-#links-button .btn.trigger:hover .line {
-    background-color: rgba(0, 0, 0, 0.7);
-}
+    #links-button .btn.trigger:hover .line {
+        background-color: rgba(0, 0, 0, 0.7);
+    }
 
-#links-button .btn.trigger:hover .line:before, #links-button .btn.trigger:hover .line:after {
-    background-color: rgba(0, 0, 0, 0.7);
+    #links-button .btn.trigger:hover .line:before, #links-button .btn.trigger:hover .line:after {
+        background-color: rgba(0, 0, 0, 0.7);
+    }
 }
 
 #links-button .btn.trigger .line {
@@ -262,9 +266,14 @@
 
 .tip { color: black; }
 
-#links-button:not(.active) .tip,
-.rotater:not(:hover) .tip {
+#links-button:not(.active) .tip{
     display: none;
+}
+
+@media (hover) {
+    .rotater:not(:hover) .tip {
+        display: none;
+    }
 }
 
 .tip {

--- a/common/views/error-report.html
+++ b/common/views/error-report.html
@@ -23,10 +23,12 @@
             top: 15px;
         }
 
-        #errorReport:hover {
-            transform: scale(1.2);
-            -moz-transform: scale(1.2);
-            -webkit-transform: scale(1.2);
+        @media (hover) {
+            #errorReport:hover {
+                transform: scale(1.2);
+                -moz-transform: scale(1.2);
+                -webkit-transform: scale(1.2);
+            }
         }
     </style>
 

--- a/damage/css/details.css
+++ b/damage/css/details.css
@@ -62,12 +62,14 @@ hr {
     width: 100%;
 }
 
-.turnContainer[current-type=""] > div:hover { background-color: rgba(0,0,0,0.1); }
-.turnContainer[current-type="STR"] > div:hover { background-color: #e27467; }
-.turnContainer[current-type="QCK"] > div:hover { background-color: #7abae2; }
-.turnContainer[current-type="DEX"] > div:hover { background-color: #82d782; }
-.turnContainer[current-type="PSY"] > div:hover { background-color: #e6c200; }
-.turnContainer[current-type="INT"] > div:hover { background-color: #c565c1; }
+@media (hover) {
+    .turnContainer[current-type=""] > div:hover { background-color: rgba(0,0,0,0.1); }
+    .turnContainer[current-type="STR"] > div:hover { background-color: #e27467; }
+    .turnContainer[current-type="QCK"] > div:hover { background-color: #7abae2; }
+    .turnContainer[current-type="DEX"] > div:hover { background-color: #82d782; }
+    .turnContainer[current-type="PSY"] > div:hover { background-color: #e6c200; }
+    .turnContainer[current-type="INT"] > div:hover { background-color: #c565c1; }
+}
 
 .turnContainer.ghosted > div {
     visibility: hidden;

--- a/damage/css/edgy.css
+++ b/damage/css/edgy.css
@@ -42,9 +42,16 @@ li.STR > div, li.QCK > div, li.DEX > div, li.PSY > div, li.INT > div {
     border-bottom: 2px solid #343d46;
 }
 
-.unit, .unit:hover {
+.unit {
     border-color: white;
     color: white;
+}
+
+@media (hover) {
+    .unit:hover {
+        border-color: white;
+        color: white;
+    }
 }
 
 .modal-header {
@@ -67,12 +74,14 @@ li.STR > div, li.QCK > div, li.DEX > div, li.PSY > div, li.INT > div {
     color: white;
 }
 
-.btn.trigger > i:hover {
-    color: black;
-}
+@media (hover) {
+    .btn.trigger > i:hover {
+        color: black;
+    }
 
-.rotater:hover .fa {
-    color: white !important;
+    .rotater:hover .fa {
+        color: white !important;
+    }
 }
 
 .fa-star {

--- a/damage/css/main.css
+++ b/damage/css/main.css
@@ -82,9 +82,11 @@ body, html {
     cursor: pointer;
 }
 
-#transient:hover {
-    background-color: #FF9E9E;
-    border-color: #EC92A0;
+@media (hover) {
+    #transient:hover {
+        background-color: #FF9E9E;
+        border-color: #EC92A0;
+    }
 }
 
 #transient > span {
@@ -132,9 +134,11 @@ body, html {
     opacity: 0.5;
 }
 
-.empty:hover {
-    border-color: black;
-    opacity: 1 !important;
+@media (hover) {
+    .empty:hover {
+        border-color: black;
+        opacity: 1 !important;
+    }
 }
 
 .unit:not(.slide) > :not([class]) {
@@ -180,8 +184,10 @@ body, html {
     z-index: 4;
 }
 
-.unitLevel:hover {
-    background: lightcoral;
+@media (hover) {
+    .unitLevel:hover {
+        background: lightcoral;
+    }
 }
 
 .unitLevel > input {
@@ -409,9 +415,11 @@ body, html {
     color: white;
 }
 
-.btn-settings:hover {
-    background: #444;
-    color: white;
+@media (hover) {
+    .btn-settings:hover {
+        background: #444;
+        color: white;
+    }
 }
 
 .btn-orchid {
@@ -419,9 +427,11 @@ body, html {
     background: orchid;
 }
 
-.btn-orchid:hover {
-    color: white;
-    background: mediumorchid;
+@media (hover) {
+    .btn-orchid:hover {
+        color: white;
+        background: mediumorchid;
+    }
 }
 
 #other > :not(:last-child) {
@@ -456,8 +466,10 @@ body, html {
     cursor: pointer;
 }
 
-.slot:not(.nohover):hover {
-    outline: 1px solid red;
+@media (hover) {
+    .slot:not(.nohover):hover {
+        outline: 1px solid red;
+    }
 }
 
 .slot.big {
@@ -529,10 +541,12 @@ nav.panel {
             transition: background 0.1s linear;
 }
 
-#menu li > div:not(.menuIcon):not(#specialDivider):not(#supertypeContainer):not(#superclassContainer):hover {
-    background: #688aac;
-    color: white !important;
-    cursor: pointer;
+@media (hover) {
+    #menu li > div:not(.menuIcon):not(#specialDivider):not(#supertypeContainer):not(#superclassContainer):hover {
+        background: #688aac;
+        color: white !important;
+        cursor: pointer;
+    }
 }
 
 ul { padding-left: 0; }
@@ -632,12 +646,14 @@ li.STR > div, li.QCK > div, li.DEX > div, li.PSY > div, li.INT > div {
 .superclass.Evolver       { background: Peru; }
 .superclass.Booster       { background: Peru; }
 
-.supertype:hover {
-    opacity: 1;
-}
+@media (hover) {
+    .supertype:hover {
+        opacity: 1;
+    }
 
-.superclass:hover {
-    opacity: 1;
+    .superclass:hover {
+        opacity: 1;
+    }
 }
 
 input:checked + .supertype {    
@@ -709,8 +725,10 @@ nav > li > div {
     margin-left: -1px;
 }
 
-.comodity:hover {
-    color: red;
+@media (hover) {
+    .comodity:hover {
+        color: red;
+    }
 }
 
 /***********
@@ -893,16 +911,18 @@ nav > li > div {
     margin-top: 5px;
 }
 
-#defense-table tbody > tr:hover,
-#defense-table tbody > td:hover,
-#ship-table tbody > tr:hover,
-#ship-table tbody > td:hover,
-#profile-table tbody > tr:hover,
-#profile-table tbody > td:hover,
-#slot-table tbody > tr:hover,
-#slot-table tbody > td:hover {
-    background-color: rgba(200,200,200,0.3);
-    cursor: pointer;
+@media (hover) {
+    #defense-table tbody > tr:hover,
+    #defense-table tbody > td:hover,
+    #ship-table tbody > tr:hover,
+    #ship-table tbody > td:hover,
+    #profile-table tbody > tr:hover,
+    #profile-table tbody > td:hover,
+    #slot-table tbody > tr:hover,
+    #slot-table tbody > td:hover {
+        background-color: rgba(200,200,200,0.3);
+        cursor: pointer;
+    }
 }
 
 .help {
@@ -1094,8 +1114,10 @@ nav > li > div {
     box-shadow: 0 0 0 1pt black;
 }
 
-.unitAbilities:hover {
-    background: lightcoral;
+@media (hover) {
+    .unitAbilities:hover {
+        background: lightcoral;
+    }
 }
 
 .candySlider {

--- a/drops/index.css
+++ b/drops/index.css
@@ -36,9 +36,11 @@ td:first-child {
     display: none;
 }
 
-h2:hover > span, h3:hover > span {
-    text-decoration: underline;
-    cursor: pointer;
+@media (hover) {
+    h2:hover > span, h3:hover > span {
+        text-decoration: underline;
+        cursor: pointer;
+    }
 }
 
 h1 > label {
@@ -83,23 +85,27 @@ h1 > label > input {
 #bonus-table td.beli    { background: rgba(127,202,159,0.2); }
 #bonus-table td.exp     { background: rgba(244,186,112,0.2); }
 
-#bonus-table tr:hover td.stamina      { background: rgba(133,193,245,1.0); }
-#bonus-table tr:hover td.drop         { background: rgba(233,109,99,1.0);  }
-#bonus-table tr:hover td.beli         { background: rgba(127,202,159,1.0); }
-#bonus-table tr:hover td.exp          { background: rgba(244,186,112,1.0); }
+@media (hover) {
+    #bonus-table tr:hover td.stamina      { background: rgba(133,193,245,1.0); }
+    #bonus-table tr:hover td.drop         { background: rgba(233,109,99,1.0);  }
+    #bonus-table tr:hover td.beli         { background: rgba(127,202,159,1.0); }
+    #bonus-table tr:hover td.exp          { background: rgba(244,186,112,1.0); }
+}
 
 #bonus-table .active {
     border-left: 1px solid darkred;
     border-right: 1px solid darkred;
 }
 
-#bonus-table tr:hover td {
-    border-top: 1px solid darkred;
-    border-bottom: 1px solid darkred;
-}
+@media (hover) {
+    #bonus-table tr:hover td {
+        border-top: 1px solid darkred;
+        border-bottom: 1px solid darkred;
+    }
 
-#bonus-table tr:hover td:first-child {
-    background: rgb(220,220,220) !important;
+    #bonus-table tr:hover td:first-child {
+        background: rgb(220,220,220) !important;
+    }
 }
 
 .tooltip-inner {
@@ -114,8 +120,10 @@ h1 > label > input {
     display: inline-block;
 }
 
-.slot:hover {
-    outline: 1px solid red;
+@media (hover) {
+    .slot:hover {
+        outline: 1px solid red;
+    }
 }
 
 .slot.small {

--- a/index.css
+++ b/index.css
@@ -86,10 +86,14 @@ body {
 .button:last-child {
     border-radius: 0 0 5px 5px;
 }
-.button:hover {
-	transform: scale(1.1);
-	font-weight:bold;
+
+@media (hover) {
+    .button:hover {
+        transform: scale(1.1);
+        font-weight:bold;
+    }
 }
+
 .green  { background-color: #7FCA9F; }
 .blue   { background-color: #85C1F5; }
 .red    { background-color: #E96D63; }
@@ -103,18 +107,20 @@ body {
 .limegreen   { background-color: #32CD32; }
 .darkorange   { background-color: #CF5300; }
 
-.green:hover  { background-color: #6EB98E; }
-.blue:hover   { background-color: #74B0E4; }
-.red:hover    { background-color: #D85C52; }
-.purple:hover { background-color: #C96995; }
-.yellow:hover { background-color: #E3A969; }
-.pink:hover   { background-color: #A57777; }
-.brown:hover   { background-color: #662200; }
-.darkpurple:hover   { background-color: #5B2C6F; }
-.gold:hover   { background-color: #947713; }
-.darkblue:hover   { background-color: #092056; }
-.limegreen:hover   { background-color: #228B22; }
-.darkorange:hover   { background-color: #B54C05; }
+@media (hover) {
+    .green:hover  { background-color: #6EB98E; }
+    .blue:hover   { background-color: #74B0E4; }
+    .red:hover    { background-color: #D85C52; }
+    .purple:hover { background-color: #C96995; }
+    .yellow:hover { background-color: #E3A969; }
+    .pink:hover   { background-color: #A57777; }
+    .brown:hover   { background-color: #662200; }
+    .darkpurple:hover   { background-color: #5B2C6F; }
+    .gold:hover   { background-color: #947713; }
+    .darkblue:hover   { background-color: #092056; }
+    .limegreen:hover   { background-color: #228B22; }
+    .darkorange:hover   { background-color: #B54C05; }
+}
 
 .overlay {
     position: absolute;
@@ -143,8 +149,10 @@ body {
     display: inline-block;
 }
 
-.slot:hover {
-    outline: 1px solid red;
+@media (hover) {
+    .slot:hover {
+        outline: 1px solid red;
+    }
 }
 
 .slot.small {

--- a/mats/index.css
+++ b/mats/index.css
@@ -52,8 +52,10 @@ h2, h2 + div {
     transform: translate(-50%,-50%);
 }
 
-#add:hover > i {
-    color: salmon;
+@media (hover) {
+    #add:hover > i {
+        color: salmon;
+    }
 }
 
 .slot {
@@ -62,8 +64,10 @@ h2, h2 + div {
     position: relative;
 }
 
-.slot:not(#add):hover {
-    outline: 1px solid red;
+@media (hover) {
+    .slot:not(#add):hover {
+        outline: 1px solid red;
+    }
 }
 
 .slot.medium {
@@ -233,12 +237,14 @@ span.animated {
     cursor: pointer;
 }
 
-#evolution-table td:hover {
-    background: #ddd;
-}
+@media (hover) {
+    #evolution-table td:hover {
+        background: #ddd;
+    }
 
-#evolution-table .slot:hover {
-    outline: none;
+    #evolution-table .slot:hover {
+        outline: none;
+    }
 }
 
 div > .pull-right {

--- a/probability/index.css
+++ b/probability/index.css
@@ -91,8 +91,10 @@ p {
 	margin: 0 auto;
 }
 
-.unit:hover {
-    border-color: red;
+@media (hover) {
+    .unit:hover {
+        border-color: red;
+    }
 }
 
 .unit.empty {
@@ -106,8 +108,10 @@ p {
     position: relative;
 }
 
-.slot:not(#add):hover {
-    outline: 1px solid red;
+@media (hover) {
+    .slot:not(#add):hover {
+        outline: 1px solid red;
+    }
 }
 
 .slot.medium {
@@ -201,9 +205,11 @@ slot-wheel > .ghoster {
     cursor: pointer;
 }
 
-#transient:hover {
-    background-color: #FF9E9E;
-    border-color: #EC92A0;
+@media (hover) {
+    #transient:hover {
+        background-color: #FF9E9E;
+        border-color: #EC92A0;
+    }
 }
 
 #transient > span {
@@ -229,8 +235,10 @@ slot-wheel > .ghoster {
     visibility: visible;
 }
 
-.quick-fill:hover {
-    background: #ddd;
+@media (hover) {
+    .quick-fill:hover {
+        background: #ddd;
+    }
 }
 
 .quick-fill-slots {
@@ -362,10 +370,12 @@ canvas {
     -moz-box-shadow: inset 0 0 1pt 1pt black, 0 0 1pt 1pt white;
 }
 
-.ability:hover {
-    box-shadow: inset 0 0 1pt 1pt black, 0 0 1pt 1pt red;
-    -webkit-box-shadow: inset 0 0 1pt 1pt black, 0 0 1pt 1pt red;
-    -moz-box-shadow: inset 0 0 1pt 1pt black, 0 0 1pt 1pt red;
+@media (hover) {
+    .ability:hover {
+        box-shadow: inset 0 0 1pt 1pt black, 0 0 1pt 1pt red;
+        -webkit-box-shadow: inset 0 0 1pt 1pt black, 0 0 1pt 1pt red;
+        -moz-box-shadow: inset 0 0 1pt 1pt black, 0 0 1pt 1pt red;
+    }
 }
 
 #ability-table td {
@@ -683,9 +693,11 @@ canvas {
     padding-top: 10px;
 }
 
-#loadSlot tr:hover {
-    background: #ddd;
-    cursor: pointer;
+@media (hover) {
+    #loadSlot tr:hover {
+        background: #ddd;
+        cursor: pointer;
+    }
 }
 
 #loadSlot td > div {

--- a/slots/index.css
+++ b/slots/index.css
@@ -89,8 +89,10 @@ html, body, body > [ui-view] {
     background-position: -1px -1px;
 }
 
-.unit:hover {
-    border-color: red;
+@media (hover) {
+    .unit:hover {
+        border-color: red;
+    }
 }
 
 .unit.empty {
@@ -104,8 +106,10 @@ html, body, body > [ui-view] {
     position: relative;
 }
 
-.slot:not(#add):hover {
-    outline: 1px solid red;
+@media (hover) {
+    .slot:not(#add):hover {
+        outline: 1px solid red;
+    }
 }
 
 .slot.medium {
@@ -192,9 +196,11 @@ slot-wheel > .ghoster {
     cursor: pointer;
 }
 
-#transient:hover {
-    background-color: #FF9E9E;
-    border-color: #EC92A0;
+@media (hover) {
+    #transient:hover {
+        background-color: #FF9E9E;
+        border-color: #EC92A0;
+    }
 }
 
 #transient > span {
@@ -224,8 +230,10 @@ slot-wheel > .ghoster {
     visibility: visible;
 }
 
-.quick-fill:hover {
-    background: #ddd;
+@media (hover) {
+    .quick-fill:hover {
+        background: #ddd;
+    }
 }
 
 .label.label-danger {
@@ -349,10 +357,12 @@ canvas {
     -moz-box-shadow: inset 0 0 1pt 1pt black, 0 0 1pt 1pt white;
 }
 
-.ability:hover {
-    box-shadow: inset 0 0 1pt 1pt black, 0 0 1pt 1pt red;
-    -webkit-box-shadow: inset 0 0 1pt 1pt black, 0 0 1pt 1pt red;
-    -moz-box-shadow: inset 0 0 1pt 1pt black, 0 0 1pt 1pt red;
+@media (hover) {
+    .ability:hover {
+        box-shadow: inset 0 0 1pt 1pt black, 0 0 1pt 1pt red;
+        -webkit-box-shadow: inset 0 0 1pt 1pt black, 0 0 1pt 1pt red;
+        -moz-box-shadow: inset 0 0 1pt 1pt black, 0 0 1pt 1pt red;
+    }
 }
 
 #ability-table td {
@@ -670,9 +680,11 @@ canvas {
     padding-top: 10px;
 }
 
-#loadSlot tr:hover {
-    background: #ddd;
-    cursor: pointer;
+@media (hover) {
+    #loadSlot tr:hover {
+        background: #ddd;
+        cursor: pointer;
+    }
 }
 
 #loadSlot td > div {

--- a/turtles/css/angular-dropdowns.css
+++ b/turtles/css/angular-dropdowns.css
@@ -94,9 +94,10 @@
 }
 
 /* Hover state */
-
-.wrap-dd-select .dropdown li:hover a {
-  background: #f3f8f8;
+@media (hover) {
+  .wrap-dd-select .dropdown li:hover a {
+    background: #f3f8f8;
+  }
 }
 
 .wrap-dd-select .dropdown:after {
@@ -194,9 +195,10 @@
 }
 
 /* Hover state */
-
-.wrap-dd-menu .dropdown li:hover a {
-  background: #f3f8f8;
+@media (hover) {
+  .wrap-dd-menu .dropdown li:hover a {
+    background: #f3f8f8;
+  }
 }
 
 .wrap-dd-menu .dropdown:after {

--- a/turtles/css/normalize.css
+++ b/turtles/css/normalize.css
@@ -94,9 +94,14 @@ a {
  * Improve readability when focused and also mouse hovered in all browsers.
  */
 
-a:active,
-a:hover {
+a:active{
   outline: 0;
+}
+
+@media (hover) {
+  a:hover {
+    outline: 0;
+  }
 }
 
 /* Text-level semantics


### PR DESCRIPTION
Touch devices don't support the hover classes conveniently, so :hover
classes would stay on after tap on mobile devices. This commit checks
if the device supports hover conveniently to apply the classes.
Reference: https://drafts.csswg.org/mediaqueries/#hover