### PR TITLE
Orb controllers

### DIFF
--- a/characters/css/index.css
+++ b/characters/css/index.css
@@ -290,6 +290,7 @@ input#burgerMenuState {
 
 #leftContainer .submatcher .submatcher-separator {
     text-align: center;
+    min-height: 10px; /* When we want to have an empty separator*/
 }
 
 #leftContainer .submatcher .submatcher-option {

--- a/characters/js/directives.js
+++ b/characters/js/directives.js
@@ -225,38 +225,6 @@ directives.addCustomFilters = function($timeout, $compile) {
     };
 };
 
-directives.addOrbOptions = function($timeout, $compile) {
-    return {
-        restrict: 'E',
-        replace: true,
-        template: '<div class="orb-controllers" ng-class="{ enabled: filters.custom[target][group].matchers[name].enabled }"></div>',
-        compile: function(element, attrs, transclude) {
-            var separator = '<span class="separator">&darr;</span>';
-            var htmlBeforeSeparator = "";
-            var htmlAfterSeparator = "";
-            [ 'STR', 'DEX', 'QCK', 'PSY', 'INT', 'RCV', 'TND', 'BLOCK', 'EMPTY', 'BOMB', 'G', 'WANO', 'RAINBOW' ].forEach(function(type) {
-                var orbTemplate = `<span class="filter orb %s" ng-class="{ active: filters.custom[target][group].matchers[name].submatchers[j].param.%f.indexOf(\'%s\') > -1 }" ng-click="onOrbClick($event, filters.custom[target][group].matchers[name].submatchers[j], \'%f\', \'%s\')">%S</span>`;
-                orbTemplate = orbTemplate.replace(/%s/g,type).replace(/%S/g,type[0]);
-                htmlBeforeSeparator += orbTemplate.replace(/%f/g,'ctrlFrom');
-                htmlAfterSeparator += orbTemplate.replace(/%f/g,'ctrlTo');
-            });
-            element.html(htmlBeforeSeparator + separator + htmlAfterSeparator);
-            return function postLink(scope, element, attrs) {
-                scope.onOrbClick = function(e, submatcherObj, fromOrTo, type) {
-                    if (!submatcherObj.param)
-                        submatcherObj.param = { ctrlFrom: [], ctrlTo: [] };
-
-                    var orbClickedIndex = submatcherObj.param[fromOrTo].indexOf(type);
-                    if (orbClickedIndex == -1)
-                        submatcherObj.param[fromOrTo].push(type);
-                    else
-                        submatcherObj.param[fromOrTo].splice(orbClickedIndex, 1);
-                };
-            };
-        },
-    };
-};
-
 directives.goBack = function($state) {
 	return {
 		restrict: 'A',

--- a/characters/views/custom-filters.html
+++ b/characters/views/custom-filters.html
@@ -55,8 +55,6 @@
                                         {{::submatcher.description}} <input type="text" ng-model="filters.custom[target][group].matchers[name].submatchers[j].param" size="11" placeholder="ex: 'luffy', 'usopp|chopper'">
                                     </label>
                                 </div>
-                                <add-orb-options ng-if="::submatcher.type == 'orbs'" class="width-12">
-                                </add-orb-options>
                                 <div ng-if="::submatcher.type == 'option'" class="filter subclass width-12 submatcher-option" ng-class="{ active: filters.custom[target][group].matchers[name].submatchers[j].param }" ng-click="toggleRadioGroup(filter, j, submatcher.radioGroup)">
                                     {{::submatcher.description}}
                                 </div>

--- a/common/tests/details.test.js
+++ b/common/tests/details.test.js
@@ -108,9 +108,10 @@ describe('Typos', () => {
                     // expect(target).toBe(corrected);
                     expect(target).toEqual(expect.not.stringMatching(/thier|recieve/));
                 });
-                it('checks for "a 8..."', () => {
-                    // should be "an 8..."
-                    expect(target).toEqual(expect.not.stringMatching(/\ba 8/)); // a 8% or a 80%
+                it('checks for "a" that should be "an"', () => {
+                    // "an 8%" or "an 80%"
+                    // "an [INT] orb" or "an [INT] character"
+                    expect(target).toEqual(expect.not.stringMatching(/\ba (8|\[INT\])/)); 
                 });
             });
         }


### PR DESCRIPTION
Feat(chars): Add better orb controller filter

Adds way to specify the regex to append for "universal" in convenience functions
in matchers.js, because the orb controllers will treat the absence of
"of ___ characters" as universal (all characters)

Removes the old orb controller logic.

Implementing the orb controllers as submatchers makes for more flexibility
(such as being able to implement it for orb randomizers, adding an "Any" To orb)
Also bigger buttons makes it more clickable for mobile.

In order to properly implement the filter for orb controllers, many descriptions
were changed to comply with the following formats:
- changes <from orbs> orbs(, including [BLOCK] orbs,)?( of <types, classes, etc>
    characters?)? into <to orbs> orbs
    (if "of ... characters" is not found, it will be interpreted as all 
    characters, like in "changes all orbs into [PSY] orbs")
- if the "from" orbs and target characters are different, they should be
    separated into two phrases
    From: "Changes own and Badly Matching orbs into [STR] orbs"
    To: "Changes the orb of this character into a [STR] orb and changes Badly
        Matching orbs into [STR] orbs"
    In this case, it will change any orb of this character, but changes only
        badly matching orbs for the whole crew, so there should be two "changes"

Changes (not all):
From: "changes right column orbs, from top to bottom, into [RCV], [INT] and
    [QCK] orbs"
To: "changes all orbs of right column characters into [RCV], [INT] and
    [QCK] orbs, from top to bottom"

From: "changes right column orbs into Matching orbs"
To: "changes all orbs of right column characters into Matching orbs"

From: "Changes left column orbs, including [BLOCK] orbs, into Matching orbs"
To: "Changes all orbs, including [BLOCK] orbs, of left column characters
    into Matching orbs"

From: "changes top and bottom row orbs into Matching orbs"
To: "changes all orbs of top and bottom row characters into Matching orbs"

From: "Changes bottom right orb to [STR] and bottom left orb to [INT]"
To: "Changes orb of bottom right character to [STR] and changes orb of
    bottom left character to [INT]"

From: "changes right column [STR], [DEX], [QCK], [PSY], or [INT] orbs into
    Matching orbs"
To: "changes [STR], [DEX], [QCK], [PSY], or [INT] orbs of right column
    characters into Matching orbs"

From: "changes right column [STR], [QCK], [DEX], [PSY] and [INT] orbs into
    Matching orbs for Shooter and Striker characters"
To: "changes [STR], [QCK], [DEX], [PSY] and [INT] orbs of right column Shooter
    and Striker characters into Matching orbs"

From: "changes own orb and the Captain's orb into Matching"
To: "changes orbs of Captain and this character into Matching orbs"

From: "changes own orb and adjacent orbs into Matching orbs"
To: "changes orbs of this and adjacent characters into Matching orbs"

From: "Changes the top right orb into [DEX], the middle right orb into [STR] and
    the bottom right orb into [QCK]"
To: "Changes orbs of right column characters into [DEX], [STR] and [QCK], from 
    top to bottom"

From: "changes the supported character's adjacent orbs into"
To: "changes orbs of adjacent characters into"
Note: even if this is supported character's adjacent characters, you should NOT
    include "the supported character" in the description, because it could be
    tagged as one that includes the supported character. "Adjacent characters"
    is clear enough.

From: "changes supported character's orb"
To: "changes the orb of the supported character"