### PR TITLE
Fix matchers not matching some units

### DIFF
--- a/common/data/matchers.js
+++ b/common/data/matchers.js
@@ -3041,7 +3041,7 @@ let matchers = {
         {
             name: 'Beneficial Orb Enablers',
             targets: [ 'captain', 'sailor' ],
-            regex: /makes ([^".]+?)orbs beneficial for ([^".]+?)characters/i,
+            regex: /makes ([^".]+?)orbs beneficial for ([^".]+?)characters?/i,
             submatchers: [
                 ...createUniversalSubmatcher([2]),
                 {
@@ -3072,7 +3072,7 @@ let matchers = {
         {
             name: 'Beneficial Orb Enablers',
             targets: [ 'special', 'superSpecial', 'swap', 'support' ],
-            regex: /makes ([^".]+?)orbs beneficial for ([^".]+?)characters for ([?\d]+\+?)(?:-([?\d]+))? turn/i,
+            regex: /makes ([^".]+?)orbs beneficial for ([^".]+?)characters? for ([?\d]+\+?)(?:-([?\d]+))? turn/i,
             submatchers: [
                 {
                     type: 'number',


### PR DESCRIPTION
Beneficial Orb Enablers - "s" in "characters" was not optional so it
    missed "for this character", and some units had typos

Debuff Reduction: Silence/Special Bind - some units still had "duration
    on ____ characters? by x turns", where the "by x turns" should have
    been right next to duration. All similar abilities (despair and the
    like) were also checked.

Thanks to u/zl1814 for finding the bugs.