### PR TITLE
Fix broken urls for big thumbnails on forks

### DIFF
--- a/characters/js/directives.js
+++ b/characters/js/directives.js
@@ -111,7 +111,7 @@ directives.decorateSlot = function() {
         scope: { uid: '=', big: '@' },
         link: function(scope, element, attrs) {
             if (scope.big)
-                element[0].style.backgroundImage = 'url(' + Utils.getBigThumbnailUrl(scope.uid) + ')';
+                element[0].style.backgroundImage = 'url(' + Utils.getBigThumbnailUrl(scope.uid, '..') + ')';
             else
                 element[0].style.backgroundImage = 'url(' + Utils.getThumbnailUrl(scope.uid, '..') + ')';
                 //element[0].style.backgroundImage = 'url(' + Utils.getGlobalThumbnailUrl(scope.uid) + '), url(' + Utils.getThumbnailUrl(scope.uid, '..') + ')';

--- a/common/js/utils.js
+++ b/common/js/utils.js
@@ -1008,7 +1008,16 @@
         return relPathToRoot + '/api/images/thumbnail/jap/' +  Math.trunc(n / 1000) + '/' + Math.trunc((n % 1000) / 100) + '00/' + id + '.png';
     };
 
-    utils.getBigThumbnailUrl = function (n) {
+    /**
+     * Function to get the url for the big thumbnail (the one shown upon checking the details of a unit)
+     * @param {number} n 1-based ID number of the unit, or skull ID.
+     * @param {string} relPathToRoot Relative path to the root folder (folder
+     *      containing 'characters', 'common', 'damage', etc), which allows the urls to work even
+     *      in setups where the root folder is not necessarily the root in terms of the url.
+     *      Will only be used for resources that are stored in the repo.
+     * @returns The URL of the big thumbnail
+     */
+    utils.getBigThumbnailUrl = function (n, relPathToRoot = '') {
         switch (n){
             case 'skullLuffy':
             case 9001: return 'https://onepiece-treasurecruise.com/wp-content/uploads/skull_luffy_c.png'; break;
@@ -1096,7 +1105,7 @@
             default: break;
         }
         
-        return '/api/images/full/transparent/' +  Math.trunc(n / 1000) + '/' + Math.trunc((n % 1000) / 100) + '00/' + id + '.png';
+        return relPathToRoot + '/api/images/full/transparent/' +  Math.trunc(n / 1000) + '/' + Math.trunc((n % 1000) / 100) + '00/' + id + '.png';
         //return 'https://onepiece-treasurecruise.com/wp-content/uploads/c' + id + '.png';
 
     };


### PR DESCRIPTION
This bug is not present on the live db site, but only on forks where the
url has a subdirectory that contains the db.