### PR TITLE
Save page length forever 

### DIFF
--- a/characters/js/directives.js
+++ b/characters/js/directives.js
@@ -16,8 +16,8 @@ directives.characterTable = function($rootScope, $timeout, $compile, $storage) {
 		template: '<table id="mainTable" class="table table-striped-column panel panel-default"></table>',
 		link: function(scope, element, attrs) {
 			window.charTable = element.dataTable({
-				iDisplayLength: $storage.get('unitsPerPage', 10),
-				stateSave: true,
+				stateSave: true, // includes page length
+                stateDuration: 0,
                 deferRender: true,
 				data: scope.table.data,
 				columns: scope.table.columns,


### PR DESCRIPTION
Removes iDisplayLength because it is overwritten by `stateSave` anyway.
stateDuration of 0 means indefinite.