### PR TITLE
Fix(damage): Fix orbPlus functions breaking

### DIFF
--- a/damage/js/cruncher.js
+++ b/damage/js/cruncher.js
@@ -988,6 +988,8 @@ var CruncherCtrl = function($scope, $rootScope, $timeout) {
                     var atkPlusTemp = 0;
                     var atkCeilTemp = 1;
                     var statusPlusTemp = 0;
+                    var orbPlusTemp = 0;
+                    var orbCeilTemp = 1;
 
                     // get highest buff increase
                     plusSpecials.forEach(function(plusSpecial) {
@@ -1004,6 +1006,12 @@ var CruncherCtrl = function($scope, $rootScope, $timeout) {
                         if(plusSpecial.hasOwnProperty('statusPlus')){
                             if(plusSpecial.statusPlus(plusParams) > statusPlusTemp)
                                 statusPlusTemp = plusSpecial.statusPlus(plusParams);
+                        }
+                        if (plusSpecial.hasOwnProperty('orbPlus')) {
+                            orbPlusTemp = Math.max(plusSpecial.orbPlus(plusParams), orbPlusTemp);
+                        }
+                        if (plusSpecial.hasOwnProperty('orbCeil')) {
+                            orbCeilTemp = Math.max(plusSpecial.orbCeil(plusParams), orbCeilTemp);
                         }
                     });
                     if (!data.s) { // non-static
@@ -1025,6 +1033,12 @@ var CruncherCtrl = function($scope, $rootScope, $timeout) {
                         } else if (data.type == "orb") {
                             if (parseFloat($scope.data.customOrb) != 1)
                                 text = 'special override';
+                            if (multiplier != 1) { // only apply if there's an orb boost
+                                if (orbCeilTemp != 1)
+                                    multiplier = orbCeilTemp;
+                                else
+                                    multiplier += orbPlusTemp;
+                            }
                             multiplier = CrunchUtils.getOrbMultiplier(params.orb, params.unit.type, params.unit.class, 1, multiplier, [params.friendCaptain, params.captain], params.effectName, params);
                         }
                         multipliers.push([ multiplier, text ]);

--- a/damage/js/utils.js
+++ b/damage/js/utils.js
@@ -162,15 +162,6 @@ window.CrunchUtils.gearSort = function(array, typeMultiplier) {
 };
 
 window.CrunchUtils.getOrbMultiplier = function(orb, type, uclass, baseMultiplier, boostedMultiplier, captains, effectName, params) {
-    var orbPlusBonus = 0;
-    var orbCeilBonus = 1;
-    if(params.enabledAbilities.specials[0]) Object.keys(params.enabledAbilities.specials).forEach(function(x) {
-        if (params.enabledAbilities.specials[x].hasOwnProperty('orbPlus')){
-            iparams = params; iparams["sourceSlot"] = params.enabledAbilities.specials[x].sourceSlot;
-            if (params.enabledAbilities.specials[x].orbPlus(iparams) > orbPlusBonus)
-                orbPlusBonus = params.enabledAbilities.specials[x].orbPlus(iparams)
-        }
-    });
     /* Object.keys(window.altspecials).forEach(function(x) {
         if (window.altspecials[x].hasOwnProperty('orbPlus')){
             if(window.altspecials[x].turnedOn)
@@ -178,14 +169,6 @@ window.CrunchUtils.getOrbMultiplier = function(orb, type, uclass, baseMultiplier
                     orbPlusBonus = window.altspecials[x].orbPlus(params)
         }
     }); */
-    if(params.enabledAbilities.specials[0]) Object.keys(params.enabledAbilities.specials).forEach(function(x) {
-        if (params.enabledAbilities.specials[x].hasOwnProperty('orbCeil')){
-            iparams = params; iparams["sourceSlot"] = params.enabledAbilities.specials[x].sourceSlot;
-            if (params.enabledAbilities.specials[x].orbCeil(iparams) > orbCeilBonus)
-                orbCeilBonus = params.enabledAbilities.specials[x].orbCeil(iparams)
-        }
-    });
-    boostedMultiplier = boostedMultiplier != 1 ? orbCeilBonus != 1 ? orbCeilBonus : boostedMultiplier + orbPlusBonus : boostedMultiplier;
 
     boostedMultiplier = parseFloat(params.customBuffs.orb) != 1 ? parseFloat(params.customBuffs.orb) : boostedMultiplier;
 


### PR DESCRIPTION
This is due to orbPlus and orbCeil specials being calculated in CrunchUtils.getOrbMultiplier, where the params sourceSlot is only quick-patched, so the cached params are not copied. I moved the calculation to cruncher.js so we have access to the correct cached params.